### PR TITLE
Added support for netcore serial updates

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -414,6 +414,13 @@ bs_upload(char *buf, int len)
                 }
             }
 #endif
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && defined(PM_CPUNET_B0N_ADDRESS)
+            rc = boot_set_pending_multi(img_num, 1);
+            if (rc) {
+                BOOT_LOG_ERR("Error %d while setting image to pending", rc);
+                goto out;
+            }
+#endif
             rc = BOOT_HOOK_CALL(boot_serial_uploaded_hook, 0, img_num, fap,
                                 img_size);
             if (rc) {

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -242,6 +242,7 @@ int boot_read_swap_state(const struct flash_area *fap,
 int boot_read_swap_state_by_id(int flash_area_id,
                                struct boot_swap_state *state);
 int boot_write_magic(const struct flash_area *fap);
+int boot_clear_magic(const struct flash_area *fap);
 int boot_write_status(const struct boot_loader_state *state, struct boot_status *bs);
 int boot_write_copy_done(const struct flash_area *fap);
 int boot_write_image_ok(const struct flash_area *fap);

--- a/boot/bootutil/src/bootutil_public.c
+++ b/boot/bootutil/src/bootutil_public.c
@@ -331,6 +331,25 @@ boot_write_magic(const struct flash_area *fap)
     return 0;
 }
 
+int
+boot_clear_magic(const struct flash_area *fap)
+{
+    uint32_t off;
+    int rc;
+
+    off = boot_magic_off(fap);
+
+    BOOT_LOG_DBG("clearing magic; fa_id=%d off=0x%lx (0x%lx)",
+                 fap->fa_id, (unsigned long)off,
+                 (unsigned long)(fap->fa_off + off));
+    rc = flash_area_write(fap, off, NULL, BOOT_MAGIC_SZ);
+    if (rc != 0) {
+        return BOOT_EFLASH;
+    }
+
+    return 0;
+}
+
 /**
  * Write trailer data; status bytes, swap_size, etc
  *

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -947,6 +947,11 @@ boot_validated_swap_type(struct boot_loader_state *state,
                 swap_type = BOOT_SWAP_TYPE_NONE;
             }
         }
+
+        int rc = boot_clear_magic(secondary_fa);
+        if (rc != 0) {
+            return BOOT_SWAP_TYPE_FAIL;
+        }
 #endif /* CONFIG_SOC_NRF5340_CPUAPP */
     }
 


### PR DESCRIPTION
Apparently serial updates of the network core has never been working (at least with single slot updates) but now works together with the application core updates using `mcumgr`.

Clearing of the magic flag is required to avoid cyclic updates (clearing the swap info is not enough).