### PR TITLE
boot: boot_serial: add custom BNO_IMAGE_TRAILER support

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -82,6 +82,21 @@ config PM_PARTITION_SIZE_MCUBOOT_SECONDARY
 	help
 	  The secondary mcuboot partition is used for net-core image
 
+config BNO_IMAGE_STATE_TRAILER
+	bool "Add support for the B&O image state trailer"
+	default n
+	depends on MCUBOOT_SERIAL_MCUMGR_SIMPLE_IMAGE_INDEX
+	help
+	  Adds support for the custom B&O image state
+	  trailer, which will then be placed as the
+	  the last part of the last flash sector in the
+	  flash area of the corresponding image.
+	  This state trailer is supported in the custom
+	  B&O NRF immutable bootloader.
+	  Current implementation is dependent on the
+	  MCUBOOT_SERIAL_MCUMGR_SIMPLE_IMAGE_INDEX
+	  option.
+
 config MCUBOOT_SERIAL_MCUMGR_SIMPLE_IMAGE_INDEX
 	bool "mcumgr:image_upload assumes n=1+image*2+slot"
 	default n


### PR DESCRIPTION
For B&O there is a requirment to have updateable bootloaders in the products. To achieve this, the NRF secure immutable bootloader (b0) is used together with 2x MCUboot. b0 is a very simple bootloader with no peripheral interactions and simply chooses between the two MCUboot slots.

For b0 to choose correctly when upgrading/downgrading MCUboot, an image trailer is added as the last bytes of the corresponding flash partition. This image trailer contains the current status of the given image, i.e. if it is ACTIVE, INACTIVE, ...
Like MCUboot, b0 is also modified to accomodate this way of reporting (and updating) status for images. This results in a strong, but hard to enforce, dependency of the trailer interface between MCUboot and b0.

This commit copies the image trailer definitions, as specified by b0. And implements writing the image trailer, with default status as TESTING, whenever one of the MCUboot partitions are flashed. For regular images, the trailer should not be written.

Additionally, to mark an image as ACTIVE, the mcumgr protocol implementation is extended slightly to also cover the `image confirm` command from the client. This command will mark the currently active image as ACTIVE and mark the inactive MCUboot as INACTIVE, thus locking the selection of the current image.

A custom Kconfig is added for the purpose. It is dependent on the MCUBOOT_SERIAL_MCUMGR_SIMPLE_IMAGE_INDEX option due to implementation details only.