### PR TITLE
pm: add inequally sized primary and secondary partitions

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -67,6 +67,21 @@ config SINGLE_APPLICATION_SLOT
 	  uploading a new application overwrites the one that previously
 	  occupied the area.
 
+config PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY
+	bool "Accept inequally sized primary and secondary partitions"
+	default n
+	help
+	  The primary partition is used for app-core
+	  image and the secondary partition is used
+	  for net-core image.
+
+config PM_PARTITION_SIZE_MCUBOOT_SECONDARY
+	hex "Size of the secondary mcuboot partition"
+	default 0x40000
+	depends on PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY
+	help
+	  The secondary mcuboot partition is used for net-core image
+
 config MCUBOOT_SERIAL_MCUMGR_SIMPLE_IMAGE_INDEX
 	bool "mcumgr:image_upload assumes n=1+image*2+slot"
 	default n

--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -17,7 +17,11 @@ mcuboot_primary:
 # slot configuration.
 #if !defined(CONFIG_SINGLE_APPLICATION_SLOT) && !defined(CONFIG_BOOT_DIRECT_XIP)
 mcuboot_secondary:
+#if defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY) && defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY)
+  size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY
+#else
   share_size: [mcuboot_primary]
+#endif /* defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY) && defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY) */
 #if defined(CONFIG_PM_EXTERNAL_FLASH_MCUBOOT_SECONDARY)
   region: external_flash
   placement:
@@ -44,7 +48,11 @@ mcuboot_secondary_pad:
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 
 mcuboot_secondary_app:
+#if defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY) && defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY)
+  size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY
+#else
   share_size: mcuboot_primary_app
+#endif /* defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_INEQUAL_PRIMARY_SECONDARY) && defined(CONFIG_PM_PARTITION_SIZE_MCUBOOT_SECONDARY) */
   placement:
     after: mcuboot_secondary_pad
 


### PR DESCRIPTION
The default configuration of MCUboot is intended to swap between two application images. Hence it makes sense that the sizes of both the primary and secondary partition are equal.

In the B&O use case, however, the secondary partition is only used to store the net-core image, while the primary partition is used to store the app-core image.
In this case it makes sense to allow inequal sizes as the net-core only has 256kB flash while the default equally sized partitions typically left around 450kB for the secondary image as well.

This is implemented as two Kconfigs. One to allow inequal sizes and one to specify the size of the secondary partition. The primary partition will eat up all residual space.