### PR TITLE
boot: zephyr: sysflash: restore FLASH_AREA_IMAGE_x macros

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -319,7 +319,33 @@ static int flash_area_id_from_upload_id(uint32_t upload_id)
     if (upload_id >= 1) {
         uint32_t image_index = (upload_id - 1) / 2;
         uint32_t slot = (upload_id - 1) % 2;
-        return flash_area_id_from_multi_image_slot(image_index, slot);
+        /* This switch is essentially a manual inlining of the
+         * `flash_area_id_from_multi_image_slot` function.
+         * The return value has been tweaked to fit the SIMPLE_IMAGE_INDEX
+         * scheme though.
+         * This solution may be preferred over tweaking the FLASH_AREA_IMAGE_x
+         * macros as they are used in other places as well.
+         * */
+        switch(slot) {
+        case 0:
+            switch(image_index) {
+            case 0: return PM_MCUBOOT_PRIMARY_ID;
+            case 1: return PM_S0_ID;
+            default: return 255;
+            }
+        case 1:
+            switch(image_index) {
+            case 0: return PM_MCUBOOT_SECONDARY_ID;
+            case 1: return PM_S1_ID;
+            default: return 255;
+            }
+    /* Case unreachable. Included for completeness
+     *  case 2:
+     *  return FLASH_AREA_IMAGE_SCRATCH;
+     * */
+        default:
+            return -1;
+        }
     }
     return -1;
 #elif defined(MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD)

--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -36,7 +36,7 @@ extern uint32_t _image_1_primary_slot_id[];
         ((x == 0) ?                            \
            PM_MCUBOOT_PRIMARY_ID :             \
          (x == 1) ?                            \
-          PM_S0_ID : \
+          PM_MCUBOOT_PRIMARY_ID : \
            255 )
 #endif
 
@@ -44,7 +44,7 @@ extern uint32_t _image_1_primary_slot_id[];
         ((x == 0) ?                   \
             PM_MCUBOOT_SECONDARY_ID:  \
         (x == 1) ?                    \
-           PM_S1_ID :  \
+           PM_MCUBOOT_SECONDARY_ID :  \
            255 )
 #else
 


### PR DESCRIPTION
When introducing the MCUBOOT_MCUMGR_SIMPLE_IMAGE_INDEX option[1], the following macros were changed:

        FLASH_AREA_IMAGE_PRIMARY(x)

        FLASH_AREA_IMAGE_SECONDARY(x)

These macros are used in other parts of the MCUboot codebase as well, so it seems more appropriate to make the config implementation a bit uglier to restore the intended behavior[2] of these macros. The SIMPLE_IMAGE_INDEX is only relevant for `boot_serial.c` to simplify the `mcumgr` image numbering.

Note: one case is unreachable and commented out since the SCRATCH
      partition definition also is not available here.

[1] https://github.com/AudioStreamingPlatform/sdk-mcuboot/commit/766be5d72bbb722aea365036588b5027ff1e5400 [2] https://github.com/nrfconnect/sdk-mcuboot/commit/7c3d7ed725919b5c0cce8688d565dec59957cb9b